### PR TITLE
block subsidy test fix

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -81,7 +81,7 @@ public:
         consensus.BIP34Hash = uint256S("0xadd8ca420f557f62377ec2be6e6f47b96cf2e68160d58aeb7b73433de834cca0");
         consensus.BIP65Height = 4394880; // 
         consensus.BIP66Height = 4394880; // 
-	consensus.workFinalBlockSubsidy = 40265288; // Final block before we reach 21bn DGB
+        consensus.workFinalBlockSubsidy = 40266213; // Final block before we reach 21bn DGB @ 2034-05-10 (potential actual supply)
 
         consensus.powLimit = ArithToUint256(~arith_uint256(0) >> 20);
         consensus.initialTarget[ALGO_ODO] = ArithToUint256(~arith_uint256(0) >> 40); // 256 difficulty

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -52,13 +52,19 @@
 
 BOOST_FIXTURE_TEST_SUITE(main_tests, TestingSetup)
 
+// checks for:
+// 1. block subsidy in the past hasn't been altered (The past is fixed but the future is malleable)
+// 2. block subsidy never increases, so subsidy(n) <= subsidy(n+1), n is a block height
+// 3. block subsidy eventually hits 0
 static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxBlocks, CAmount* nSumOut)
 {
+    const CAmount BlockHeightVerbatimCheck = 14394800; // ~(2022-01-21)
     CAmount nSum = 0;
     CAmount nInitialSubsidy = 72000 * COIN;
 
     CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 0
     BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
+    BOOST_REQUIRE(BlockHeightVerbatimCheck <= nMaxBlocks);  // sanity check
 
     /* Before first hard fork */
 
@@ -67,7 +73,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     {
         int nHeight = nBlocks;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK_EQUAL(nSubsidy, nInitialSubsidy);
+        BOOST_REQUIRE_EQUAL(nSubsidy, nInitialSubsidy);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -78,7 +84,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     {
         int nHeight = nBlocks;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK_EQUAL(nSubsidy, 16000 * COIN);
+        BOOST_REQUIRE_EQUAL(nSubsidy, 16000 * COIN);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -89,7 +95,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     {
         int nHeight = nBlocks;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK_EQUAL(nSubsidy, 8000 * COIN);  
+        BOOST_REQUIRE_EQUAL(nSubsidy, 8000 * COIN);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -108,7 +114,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
             nExpectedSubsidy -= nExpectedSubsidy / 200; // dec by 0.5%
         }
 
-        BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+        BOOST_REQUIRE_EQUAL(nSubsidy, nExpectedSubsidy);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -127,7 +133,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
             nExpectedSubsidy -= nExpectedSubsidy / 100; // dec by 1% per month
         }
 
-        BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+        BOOST_REQUIRE_EQUAL(nSubsidy, nExpectedSubsidy);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -136,12 +142,11 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     {
         // Updated dynamic mining rewards from block height 1,430,000 to max block height.
         // Intended blockheight: 41.6 million
-        // Actual blockheight: 110.5 million
         CAmount nExpectedSubsidyStart = 2157 * COIN / 2;
         CAmount nExpectedSubsidy = nExpectedSubsidyStart;
         int nMonthsConsidered = 0;
 
-        for (int nBlocks = consensusParams.workComputationChangeTarget; nBlocks < nMaxBlocks; ++nBlocks) {
+        for (int nBlocks = consensusParams.workComputationChangeTarget; nBlocks < BlockHeightVerbatimCheck; ++nBlocks) {
             int nHeight = nBlocks;
             CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
 
@@ -162,17 +167,30 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
                 }
             }
 
-            BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+            BOOST_REQUIRE_EQUAL(nSubsidy, nExpectedSubsidy);
 
             nSum += nSubsidy;
+            nPreviousSubsidy = nSubsidy;
+            DEBUG(nBlocks, nSubsidy);
+        }
+    }
+
+    {
+        // Future block checks which don't need to exactly match anything
+        for (int nBlocks = BlockHeightVerbatimCheck; nBlocks < nMaxBlocks; ++nBlocks) {
+            int nHeight = nBlocks;
+            CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+
+            BOOST_REQUIRE_LE(nSubsidy, nPreviousSubsidy);
+
+            nSum += nSubsidy;
+            nPreviousSubsidy = nSubsidy;
             DEBUG(nBlocks, nSubsidy);
         }
     }
 
     CAmount nSubsidy = GetBlockSubsidy(nMaxBlocks, consensusParams);
-    CAmount nExpectedSubsidy = 1 * COIN;
-
-    BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+    BOOST_REQUIRE_EQUAL(nSubsidy, 0);
 
     if (nSumOut != NULL) {
         *nSumOut = nSum;
@@ -186,7 +204,7 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
     const auto testChainParams = CreateChainParams(CBaseChainParams::TESTNET);
     TestBlockSubsidy(chainParams->GetConsensus(), END_OF_SUPPLY_CURVE, &sum); // Mainnet
 
-    CAmount nExpectedTotalSupply = 2239167398214795680ULL;
+    CAmount nExpectedTotalSupply = 2100024577003013036ULL;  // this is the maximum supply, not the actual supply
     BOOST_CHECK_EQUAL(sum, nExpectedTotalSupply);
 
 #if OUTPUT_SUPPLY_SAMPLES_ENABLED


### PR DESCRIPTION
1. modified the test to have a verbatium block check height, above
   which it only checks for non-increasing rewards
2. modified the test to check for the block subsidy to eventually
   become 0 (instead of 1)
3. changed the block height where the subsidy becomes 0
4. changed the maximum total supply check (not the same as the actual
   supply)
5. Abort test on first failure to avoid filling up the log